### PR TITLE
Implement I2C

### DIFF
--- a/wpilib/src/i2c.rs
+++ b/wpilib/src/i2c.rs
@@ -66,9 +66,7 @@ impl I2C {
     ///
     /// Returns a result based on whether the transaction was successful
     pub fn write(&self, register_address: u8, data: u8) -> io::Result<usize> {
-        let mut buf = [0u8; 2];
-        buf[0] = register_address;
-        buf[1] = data;
+        let buf = [register_address, data];
 
         let status = unsafe {
             HAL_WriteI2C(

--- a/wpilib/src/i2c.rs
+++ b/wpilib/src/i2c.rs
@@ -10,14 +10,14 @@ pub enum Port {
 
 pub struct I2C {
     port: Port,
-    device_address: i32,
+    device_address: u16,
 }
 
 impl I2C {
     /// Constructs a new I2C
     ///
     /// `port` is the I2C port to which the device is connected, and `device_address` is the address of the device on the bus
-    pub fn new(port: Port, device_address: i32) -> HalResult<Self> {
+    pub fn new(port: Port, device_address: u16) -> HalResult<Self> {
         hal_call!(HAL_InitializeI2C(port as HAL_I2CPort::Type))?;
         usage::report(usage::resource_types::I2C, 0);
         Ok(I2C {
@@ -38,7 +38,7 @@ impl I2C {
         let status = unsafe {
             HAL_TransactionI2C(
                 self.port as HAL_I2CPort::Type,
-                self.device_address,
+                i32::from(self.device_address),
                 data_to_send.as_ptr(),
                 data_to_send.len() as i32,
                 data_received.as_mut_ptr(),
@@ -71,7 +71,7 @@ impl I2C {
         let status = unsafe {
             HAL_WriteI2C(
                 self.port as HAL_I2CPort::Type,
-                self.device_address,
+                i32::from(self.device_address),
                 buf.as_ptr(),
                 buf.len() as i32,
             )
@@ -90,7 +90,7 @@ impl I2C {
         let status = unsafe {
             HAL_WriteI2C(
                 self.port as HAL_I2CPort::Type,
-                self.device_address,
+                i32::from(self.device_address),
                 data.as_ptr(),
                 data.len() as i32,
             )
@@ -110,7 +110,7 @@ impl I2C {
     pub fn read(&self, register_address: i32, buf: &mut [u8]) -> io::Result<usize> {
         if buf.is_empty() {
             return Err(io::Error::new(
-                io::ErrorKind::Other,
+                io::ErrorKind::InvalidInput,
                 "Write buffer length < 1",
             ));
         }
@@ -128,7 +128,7 @@ impl I2C {
         let status = unsafe {
             HAL_ReadI2C(
                 self.port as HAL_I2CPort::Type,
-                self.device_address,
+                i32::from(self.device_address),
                 buf.as_mut_ptr(),
                 buf.len() as i32,
             )

--- a/wpilib/src/i2c.rs
+++ b/wpilib/src/i2c.rs
@@ -146,14 +146,11 @@ impl I2C {
     /// The device must support and be configured to use register
     /// auto-increment.
     pub fn verify_sensor(&self, register_address: i32, expected: &[u8]) -> bool {
-        let mut i = 0;
-        let mut cur_register_address = register_address;
-
-        loop {
-            if i >= expected.len() {
-                break;
-            }
-
+        // (register_address..).step_by(4) gets truncated to the length of the first iter when we zip
+        for (i, cur_register_address) in (0..expected.len())
+            .step_by(4)
+            .zip((register_address..).step_by(4))
+        {
             let to_read = if expected.len() - i < 4 {
                 expected.len() - i
             } else {
@@ -171,9 +168,6 @@ impl I2C {
                     return false;
                 }
             }
-
-            i += 4;
-            cur_register_address += 4;
         }
 
         true

--- a/wpilib/src/i2c.rs
+++ b/wpilib/src/i2c.rs
@@ -22,7 +22,7 @@ impl I2C {
         })
     }
 
-    pub fn transaction(&self, data_to_send: &[u8], data_received: &mut [u8]) -> HalResult<()> {
+    pub fn transaction(&self, data_to_send: &[u8], data_received: &mut [u8]) -> bool {
         let status = unsafe {
             HAL_TransactionI2C(
                 self.port as HAL_I2CPort::Type,
@@ -34,18 +34,14 @@ impl I2C {
             )
         };
 
-        if status < 0 {
-            Ok(())
-        } else {
-            Err(HalError::from(status))
-        }
+        status < 0
     }
 
-    pub fn address_only(&self) -> HalResult<()> {
+    pub fn address_only(&self) -> bool {
         self.transaction(&[], &mut [])
     }
 
-    pub fn write(&self, register_address: i32, data: u8) -> HalResult<()> {
+    pub fn write(&self, register_address: i32, data: u8) -> bool {
         let mut buf = [0u8; 2];
         buf[0] = register_address as u8; // TODO: Is this valid?
         buf[1] = data;
@@ -59,14 +55,10 @@ impl I2C {
             )
         };
 
-        if status < 0 {
-            Ok(())
-        } else {
-            Err(HalError::from(status))
-        }
+        status < 0
     }
 
-    pub fn write_bulk(&self, data: Vec<u8>) -> HalResult<()> {
+    pub fn write_bulk(&self, data: Vec<u8>) -> bool {
         let status = unsafe {
             HAL_WriteI2C(
                 self.port as HAL_I2CPort::Type,
@@ -76,14 +68,10 @@ impl I2C {
             )
         };
 
-        if status < 0 {
-            Ok(())
-        } else {
-            Err(HalError::from(status))
-        }
+        status < 0
     }
 
-    pub fn read(&self, register_address: i32, buf: &mut [u8]) -> HalResult<()> {
+    pub fn read(&self, register_address: i32, buf: &mut [u8]) -> bool {
         if buf.is_empty() {
             return Ok(());
         }
@@ -91,7 +79,7 @@ impl I2C {
         self.transaction(&[register_address as u8], buf)
     }
 
-    pub fn read_only(&self, buf: &mut [u8]) -> HalResult<()> {
+    pub fn read_only(&self, buf: &mut [u8]) -> bool {
         let status = unsafe {
             HAL_ReadI2C(
                 self.port as HAL_I2CPort::Type,
@@ -101,11 +89,7 @@ impl I2C {
             )
         };
 
-        if status < 0 {
-            Ok(())
-        } else {
-            Err(HalError::from(status))
-        }
+        status < 0
     }
 
     pub fn verify_sensor(&self, register_address: i32, expected: &[u8]) -> bool {

--- a/wpilib/src/i2c.rs
+++ b/wpilib/src/i2c.rs
@@ -1,3 +1,4 @@
+use std::cmp;
 use std::io;
 use wpilib_sys::*;
 
@@ -151,11 +152,7 @@ impl I2C {
             .step_by(4)
             .zip((register_address..).step_by(4))
         {
-            let to_read = if expected.len() - i < 4 {
-                expected.len() - i
-            } else {
-                4
-            };
+            let to_read = cmp::min(4, expected.len() - i);
 
             let mut buf = vec![0; to_read];
 

--- a/wpilib/src/i2c.rs
+++ b/wpilib/src/i2c.rs
@@ -1,0 +1,152 @@
+use wpilib_sys::*;
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+#[repr(i32)]
+pub enum Port {
+    Onboard = HAL_I2CPort::HAL_I2C_kOnboard,
+    MXP = HAL_I2CPort::HAL_I2C_kMXP,
+}
+
+pub struct I2C {
+    port: Port,
+    device_address: i32,
+}
+
+impl I2C {
+    pub fn new(port: Port, device_address: i32) -> HalResult<Self> {
+        hal_call!(HAL_InitializeI2C(port as HAL_I2CPort::Type))?;
+        usage::report(usage::resource_types::I2C, 0);
+        Ok(I2C {
+            port,
+            device_address,
+        })
+    }
+
+    pub fn transaction(&self, data_to_send: &[u8], data_received: &mut [u8]) -> HalResult<()> {
+        let status = unsafe {
+            HAL_TransactionI2C(
+                self.port as HAL_I2CPort::Type,
+                self.device_address,
+                data_to_send.as_ptr(),
+                data_to_send.len() as i32,
+                data_received.as_mut_ptr(),
+                data_received.len() as i32,
+            )
+        };
+
+        if status < 0 {
+            Ok(())
+        } else {
+            Err(HalError::from(status))
+        }
+    }
+
+    pub fn address_only(&self) -> HalResult<()> {
+        self.transaction(&[], &mut [])
+    }
+
+    pub fn write(&self, register_address: i32, data: u8) -> HalResult<()> {
+        let mut buf = [0u8; 2];
+        buf[0] = register_address as u8; // TODO: Is this valid?
+        buf[1] = data;
+
+        let status = unsafe {
+            HAL_WriteI2C(
+                self.port as HAL_I2CPort::Type,
+                self.device_address,
+                buf.as_ptr(),
+                buf.len() as i32,
+            )
+        };
+
+        if status < 0 {
+            Ok(())
+        } else {
+            Err(HalError::from(status))
+        }
+    }
+
+    pub fn write_bulk(&self, data: Vec<u8>) -> HalResult<()> {
+        let status = unsafe {
+            HAL_WriteI2C(
+                self.port as HAL_I2CPort::Type,
+                self.device_address,
+                data.as_ptr(),
+                data.len() as i32,
+            )
+        };
+
+        if status < 0 {
+            Ok(())
+        } else {
+            Err(HalError::from(status))
+        }
+    }
+
+    pub fn read(&self, register_address: i32, buf: &mut [u8]) -> HalResult<()> {
+        if buf.is_empty() {
+            return Ok(());
+        }
+
+        self.transaction(&[register_address as u8], buf)
+    }
+
+    pub fn read_only(&self, buf: &mut [u8]) -> HalResult<()> {
+        let status = unsafe {
+            HAL_ReadI2C(
+                self.port as HAL_I2CPort::Type,
+                self.device_address,
+                buf.as_mut_ptr(),
+                buf.len() as i32,
+            )
+        };
+
+        if status < 0 {
+            Ok(())
+        } else {
+            Err(HalError::from(status))
+        }
+    }
+
+    pub fn verify_sensor(&self, register_address: i32, expected: &[u8]) -> bool {
+        let mut i = 0;
+        let mut cur_register_address = register_address;
+
+        loop {
+            if i >= expected.len() {
+                break;
+            }
+
+            let to_read = if expected.len() - i < 4 {
+                expected.len() - i
+            } else {
+                4
+            };
+
+            let mut buf = vec![0; to_read];
+
+            if self.read(cur_register_address, &mut buf[..]).is_err() {
+                return false;
+            }
+
+            for j in 0..to_read {
+                if buf[j] != expected[i + j] {
+                    return false;
+                }
+            }
+
+            i += 4;
+            cur_register_address += 4;
+        }
+
+        true
+    }
+}
+
+impl Drop for I2C {
+    fn drop(&mut self) {
+        unsafe {
+            HAL_CloseI2C(self.port as HAL_I2CPort::Type);
+        }
+    }
+}

--- a/wpilib/src/i2c.rs
+++ b/wpilib/src/i2c.rs
@@ -73,7 +73,7 @@ impl I2C {
 
     pub fn read(&self, register_address: i32, buf: &mut [u8]) -> bool {
         if buf.is_empty() {
-            return Ok(());
+            return true;
         }
 
         self.transaction(&[register_address as u8], buf)
@@ -109,7 +109,7 @@ impl I2C {
 
             let mut buf = vec![0; to_read];
 
-            if self.read(cur_register_address, &mut buf[..]).is_err() {
+            if self.read(cur_register_address, &mut buf[..]) {
                 return false;
             }
 

--- a/wpilib/src/lib.rs
+++ b/wpilib/src/lib.rs
@@ -17,6 +17,7 @@ pub use self::pdp::PowerDistributionPanel;
 pub mod dio;
 pub mod ds;
 pub mod encoder;
+pub mod i2c;
 pub mod notifier;
 pub mod pneumatics;
 pub mod pwm;


### PR DESCRIPTION
Implement I2C based on the wpilibc I2C.cpp implementation. Fixes #51 