### PR TITLE
wpilib-sys: Add links manifest key

### DIFF
--- a/wpilib-sys/Cargo.toml
+++ b/wpilib-sys/Cargo.toml
@@ -10,6 +10,7 @@ name = "wpilib-sys"
 version = "0.4.0"
 authors = ["Josh Hejna <josh.hejna@gmail.com>"]
 build = "build.rs"
+links = "wpiHal"
 description = "FRC's WPILib system bindings for rust."
 repository = "https://github.com/Lytigas/first-rust-competition"
 keywords = ["frc", "roborio", "robotics", "first", "wpilib"]


### PR DESCRIPTION
It is not possible to link to multiple versions of a
native library.  *-sys crates should always have a
links manifest key to inform Cargo of this.

https://doc.rust-lang.org/cargo/reference/build-scripts.html#the-links-manifest-key