### PR TITLE
relay: Split BiRelay from Relay

### DIFF
--- a/wpilib/src/relay.rs
+++ b/wpilib/src/relay.rs
@@ -29,7 +29,7 @@ impl RelayHandle {
         Ok(relay)
     }
 
-    fn get(&self) -> HalResult<()> {
+    fn get(&self) -> HalResult<bool> {
         Ok(hal_call!(HAL_GetRelay(self.0))? != 0)
     }
 

--- a/wpilib/src/relay.rs
+++ b/wpilib/src/relay.rs
@@ -11,23 +11,7 @@
 //! The relay channels control a pair of pins which can be independently
 //! toggled on or off.  This can allow off, full forward, or full reverse
 //! control of motors without variable speed.
-//!
-//! # Examples
-//!
-//! Using a bidirectional relay:
-//!
-//! ```
-//! use wpilib::relay;
-//!
-//! # fn main() -> wpilib::HalResult<()> {
-//! let mut relay = relay::Relay<relay::BothDirections>::new(1)?;
-//!
-//! relay.set(relay::Value::Forward)?;
-//! assert_eq!(relay.get(), relay::Value::Forward);
-//! # }
-//! ```
 
-use std::marker::PhantomData;
 use wpilib_sys::*;
 
 /// Possible values for a bidirectional relay.
@@ -43,99 +27,53 @@ pub enum Value {
     Reverse,
 }
 
-/*
-/// Convenience for treating bidirectional and unidirectional relays the same.
-impl From<bool> for Value {
-    fn from(v: bool) -> Self {
-        if v {
-            Value::On
-        } else {
-            Value::Off
-        }
-    }
-}
-*/
-
-#[derive(Debug)]
-/// Marker specifying a Relay goes in both directions.
-pub struct BothDirections;
-#[derive(Debug)]
-/// Marker specifying a Relay goes forward only.
-pub struct ForwardOnly;
-#[derive(Debug)]
-/// Marker specifying a Relay goes reverse only.
-pub struct ReverseOnly;
-
-/// Marker trait for direction type parameter for Relay.
+/// Interface for bidirectional Spike-style relay outputs.
 ///
-/// This trait is sealed and cannot be implemented outside of this crate.
-pub trait Direction: private::Sealed {
-    #[doc(hidden)]
-    const FORWARD: bool = true;
-    #[doc(hidden)]
-    const REVERSE: bool = true;
-}
-impl Direction for BothDirections {}
-impl Direction for ForwardOnly {
-    #[doc(hidden)]
-    const REVERSE: bool = false;
-}
-impl Direction for ReverseOnly {
-    #[doc(hidden)]
-    const FORWARD: bool = false;
-}
-
-/// Interface for Spike-style relay outputs.
+/// # Examples
 ///
-/// See the module-level docs for more details.
+/// ```
+/// # fn main() -> wpilib::HalResult<()> {
+/// let mut relay = BiRelay::new(1)?;
+///
+/// relay.set(Value::Forward)?;
+/// assert_eq!(relay.get(), Value::Forward);
+/// # }
+/// ```
 #[derive(Debug)]
-pub struct Relay<DIR: Direction> {
+pub struct BiRelay {
     forward_handle: HAL_RelayHandle,
     reverse_handle: HAL_RelayHandle,
     channel: i32,
-    direction: PhantomData<DIR>,
 }
 
-impl<DIR: Direction> Relay<DIR> {
-    /// Creates a Relay given a channel.
+impl BiRelay {
+    /// Creates a BiRelay given a channel.
     ///
     /// The relay will be initialized such that both lines are initially 0V.
     pub fn new(channel: i32) -> HalResult<Self> {
         let port_handle = unsafe { HAL_GetPort(channel) };
 
-        let forward_handle = if DIR::FORWARD {
-            usage::report(usage::resource_types::Relay, channel as _);
-            hal_call!(HAL_InitializeRelayPort(port_handle, true as HAL_Bool))?
-        } else {
-            HAL_kInvalidHandle
-        };
-        let reverse_handle = if DIR::REVERSE {
-            usage::report(
-                usage::resource_types::Relay,
-                channel as usage::instances::Type + 128,
-            );
-            hal_call!(HAL_InitializeRelayPort(port_handle, false as HAL_Bool))?
-        } else {
-            HAL_kInvalidHandle
-        };
+        let forward_handle = hal_call!(HAL_InitializeRelayPort(port_handle, true as HAL_Bool))?;
+        let reverse_handle = hal_call!(HAL_InitializeRelayPort(port_handle, false as HAL_Bool))?;
 
-        if forward_handle != HAL_kInvalidHandle {
-            hal_call!(HAL_SetRelay(forward_handle, false as HAL_Bool))?
-        }
-        if reverse_handle != HAL_kInvalidHandle {
-            hal_call!(HAL_SetRelay(reverse_handle, false as HAL_Bool))?
-        }
+        usage::report(usage::resource_types::Relay, channel as _);
+        usage::report(
+            usage::resource_types::Relay,
+            channel as usage::instances::Type + 128,
+        );
 
-        Ok(Self {
+        let mut relay = Self {
             forward_handle,
             reverse_handle,
             channel,
-            direction: PhantomData,
-        })
-    }
-}
+        };
 
-impl Relay<BothDirections> {
+        relay.set_forward(false)?;
+        relay.set_reverse(false)?;
+
+        Ok(relay)
+    }
+
     /// Set the relay state.
     pub fn set(&mut self, value: Value) -> HalResult<()> {
         self.set_forward(match value {
@@ -146,6 +84,16 @@ impl Relay<BothDirections> {
             Value::On | Value::Reverse => true,
             _ => false,
         })
+    }
+
+    /// Set the forward output only (independent of the reverse output).
+    fn set_forward(&mut self, on: bool) -> HalResult<()> {
+        hal_call!(HAL_SetRelay(self.forward_handle, on as HAL_Bool))
+    }
+
+    /// Set the reverse output only (independent of the forward output).
+    fn set_reverse(&mut self, on: bool) -> HalResult<()> {
+        hal_call!(HAL_SetRelay(self.reverse_handle, on as HAL_Bool))
     }
 
     /// Get the relay state.
@@ -160,60 +108,95 @@ impl Relay<BothDirections> {
             (false, false) => Ok(Value::Off),
         }
     }
-}
 
-impl Relay<ForwardOnly> {
-    pub fn set(&mut self, value: bool) -> HalResult<()> {
-        self.set_forward(value)
-    }
-
-    pub fn get(&self) -> HalResult<bool> {
-        Ok(hal_call!(HAL_GetRelay(self.forward_handle))? != 0)
-    }
-}
-
-impl Relay<ReverseOnly> {
-    pub fn set(&mut self, value: bool) -> HalResult<()> {
-        self.set_reverse(value)
-    }
-
-    pub fn get(&self) -> HalResult<bool> {
-        Ok(hal_call!(HAL_GetRelay(self.reverse_handle))? != 0)
-    }
-}
-
-impl<DIR: Direction> Relay<DIR> {
+    /// Get the channel number for this relay.
     pub fn channel(&self) -> i32 {
         self.channel
     }
-
-    fn set_forward(&mut self, value: bool) -> HalResult<()> {
-        hal_call!(HAL_SetRelay(self.forward_handle, value as HAL_Bool))
-    }
-
-    fn set_reverse(&mut self, value: bool) -> HalResult<()> {
-        hal_call!(HAL_SetRelay(self.reverse_handle, value as HAL_Bool))
-    }
 }
 
-impl<DIR: Direction> Drop for Relay<DIR> {
+impl Drop for BiRelay {
     fn drop(&mut self) {
         // ignore errors, as we want to make sure a free happens
-        if self.forward_handle != HAL_kInvalidHandle {
-            let _ = self.set_forward(false);
-            unsafe { HAL_FreeRelayPort(self.forward_handle) }
-        }
-        if self.reverse_handle != HAL_kInvalidHandle {
-            let _ = self.set_reverse(false);
-            unsafe { HAL_FreeRelayPort(self.reverse_handle) }
-        }
+        let _ = self.set_forward(false);
+        let _ = self.set_reverse(false);
+
+        unsafe { HAL_FreeRelayPort(self.forward_handle) }
+        unsafe { HAL_FreeRelayPort(self.reverse_handle) }
     }
 }
 
-// Seal the Direction trait.
-mod private {
-    pub trait Sealed {}
-    impl Sealed for super::BothDirections {}
-    impl Sealed for super::ForwardOnly {}
-    impl Sealed for super::ReverseOnly {}
+/// Possible directions for a unidirectional relay.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub enum Direction {
+    Reverse,
+    Forward,
+}
+
+/// Interface for unidirectional Spike-style relay outputs.
+///
+/// # Examples
+///
+/// ```
+/// # fn main() -> wpilib::HalResult<()> {
+/// let mut relay = Relay::new(1, Direction::Forward)?;
+///
+/// relay.set(true)?;
+/// assert_eq!(relay.get(), true);
+/// # }
+/// ```
+#[derive(Debug)]
+pub struct Relay {
+    handle: HAL_RelayHandle,
+    channel: i32,
+}
+
+impl Relay {
+    /// Creates a Relay given a channel.
+    ///
+    /// The relay will be initialized such that it is initially 0V.
+    pub fn new(channel: i32, direction: Direction) -> HalResult<Self> {
+        let handle = hal_call!(HAL_InitializeRelayPort(
+            HAL_GetPort(channel),
+            (direction == Direction::Forward) as HAL_Bool,
+        ))?;
+
+        usage::report(
+            usage::resource_types::Relay,
+            channel as usage::instances::Type
+                + match direction {
+                    Direction::Forward => 0,
+                    Direction::Reverse => 128,
+                },
+        );
+
+        let mut relay = Self { handle, channel };
+
+        relay.set(false)?;
+
+        Ok(relay)
+    }
+
+    /// Set the relay state.
+    pub fn set(&mut self, on: bool) -> HalResult<()> {
+        hal_call!(HAL_SetRelay(self.handle, on as HAL_Bool))
+    }
+
+    /// Get the relay state.
+    pub fn get(&self) -> HalResult<bool> {
+        Ok(hal_call!(HAL_GetRelay(self.handle))? != 0)
+    }
+
+    /// Get the channel number for this relay.
+    pub fn channel(&self) -> i32 {
+        self.channel
+    }
+}
+
+impl Drop for Relay {
+    fn drop(&mut self) {
+        // ignore errors, as we want to make sure a free happens
+        let _ = self.set(false);
+        unsafe { HAL_FreeRelayPort(self.handle) }
+    }
 }


### PR DESCRIPTION
This splits the bidirectional relay functionality from the Relay type, which now only handles unidirectional relays.