### PR TITLE
wpilib: Add safe wrappers for observe functions

### DIFF
--- a/wpilib/src/lib.rs
+++ b/wpilib/src/lib.rs
@@ -19,6 +19,7 @@ pub mod ds;
 pub mod encoder;
 pub mod i2c;
 pub mod notifier;
+pub mod observe;
 pub mod pneumatics;
 pub mod pwm;
 pub mod relay;

--- a/wpilib/src/observe.rs
+++ b/wpilib/src/observe.rs
@@ -1,0 +1,53 @@
+// Copyright 2020 First Rust Competition Developers.
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! Functions to report the robot status to the Driver Station.
+//!
+//! These functions are called by the IterativeRobot starter functions for you.
+//!
+//! Calling these functions will generate a corresponding event in the DS log.
+//!
+//! The mode functions must be called at least ever 50ms,
+//! otherwise the DS will disable the robot.
+
+use wpilib_sys::{
+    HAL_ObserveUserProgramAutonomous, HAL_ObserveUserProgramDisabled,
+    HAL_ObserveUserProgramStarting, HAL_ObserveUserProgramTeleop, HAL_ObserveUserProgramTest,
+};
+
+/// Tell the Driver Station that the robot is ready to be enabled.
+///
+/// This should be called once all hardware is initialised.
+/// This must be called to allow the Driver Station to enable the robot.
+#[inline]
+pub fn start() {
+    unsafe { HAL_ObserveUserProgramStarting() }
+}
+
+/// Acknowledge to the Driver Station that we are running disabled.
+#[inline]
+pub fn disabled() {
+    unsafe { HAL_ObserveUserProgramDisabled() }
+}
+
+/// Acknowledge to the Driver Station that we are running autonomous enabled.
+#[inline]
+pub fn autonomous() {
+    unsafe { HAL_ObserveUserProgramAutonomous() }
+}
+
+/// Acknowledge to the Driver Station that we are running teleoperated enabled.
+#[inline]
+pub fn teleop() {
+    unsafe { HAL_ObserveUserProgramTeleop() }
+}
+
+/// Acknowledge to the Driver Station that we are running test mode.
+#[inline]
+pub fn test() {
+    unsafe { HAL_ObserveUserProgramTest() }
+}

--- a/wpilib/src/robot.rs
+++ b/wpilib/src/robot.rs
@@ -8,13 +8,10 @@
 use super::{
     ds::{DriverStation, RobotState},
     notifier::Alarm,
-    RobotBase,
+    observe, RobotBase,
 };
 use std::time;
-use wpilib_sys::{
-    usage, HAL_ObserveUserProgramAutonomous, HAL_ObserveUserProgramDisabled,
-    HAL_ObserveUserProgramStarting, HAL_ObserveUserProgramTeleop, HAL_ObserveUserProgramTest,
-};
+use wpilib_sys::usage;
 
 /// Implements a specific type of robot program framework, for
 /// `start_iterative` and `start_timed`.
@@ -68,19 +65,19 @@ fn loop_func<T: IterativeRobot>(
     // Call the appropriate periodic function
     match cur_mode {
         RobotState::Autonomous => {
-            unsafe { HAL_ObserveUserProgramAutonomous() }
+            observe::autonomous();
             robot.autonomous_periodic()
         }
         RobotState::Teleop => {
-            unsafe { HAL_ObserveUserProgramTeleop() }
+            observe::teleop();
             robot.teleop_periodic()
         }
         RobotState::Test => {
-            unsafe { HAL_ObserveUserProgramTest() }
+            observe::test();
             robot.test_periodic()
         }
         _ => {
-            unsafe { HAL_ObserveUserProgramDisabled() }
+            observe::disabled();
             robot.disabled_periodic()
         }
     }
@@ -109,7 +106,7 @@ pub fn start_iterative<T: IterativeRobot>() -> ! {
     );
 
     // Tell the DS that the robot is ready to be enabled
-    unsafe { HAL_ObserveUserProgramStarting() }
+    observe::start();
 
     loop {
         ds.wait_for_data();
@@ -148,7 +145,7 @@ pub fn start_timed_with_period<T: IterativeRobot>(period: time::Duration) {
     );
 
     // Tell the DS that the robot is ready to be enabled
-    unsafe { HAL_ObserveUserProgramStarting() }
+    observe::start();
 
     let mut expiration_time =
         RobotBase::fpga_time().expect("Failed to read current FPGA time") + period;

--- a/wpilib/src/robot_base.rs
+++ b/wpilib/src/robot_base.rs
@@ -30,7 +30,7 @@ option. This file may not be copied, modified, or distributed
 except according to those terms.
 */
 
-use super::ds::*;
+use super::{ds::*, observe};
 use std::mem;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
@@ -73,9 +73,7 @@ impl RobotBase {
     /// Call when your robot is ready to be enabled.
     /// Make sure your hardware and threads have been created, etc.
     pub fn start_competition() {
-        unsafe {
-            HAL_ObserveUserProgramStarting();
-        }
+        observe::start();
         println!("\n********** Robot program starting **********\n");
     }
 


### PR DESCRIPTION
This makes it easier for users not using the IterativeRobot trait.