### PR TITLE
Replace Travis CI w/ Github Actions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,37 @@
+name: Publish Docker Images
+
+on:
+  push:
+    branches: [master]
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }} # TODO create org secret
+          password: ${{ secrets.DOCKER_PASSWORD }} # TODO create org secret
+      - name: Pull image
+        run: docker pull ${{ secrets.DOCKER_USERNAME }}/frc:latest
+      - name: Build container # TODO run a script, or use action?
+        run: docker build --pull -t ${{ secrets.DOCKER_PASSWORD }}/frc:${{ github.sha }} -t ${{ secrets.DOCKER_PASSWORD }}/frc:latest . --cache-from ${{ secrets.DOCKER_PASSWORD }}/frc:latest
+      - name: Publish
+        run: docker run -it -e CRATESIO_TOKEN -e TRAVIS_TAG "$DOCKER_USERNAME"/frc:"$TRAVIS_COMMIT" sh -c "cd /first-rust-competition; make ci"
+        env:
+          CRATESIO_TOKEN: ${{ secrets.CRATESIO_TOKEN }}
+          TRAVIS_TAG: ${{ github.sha }}
+      - name: Push image with latest tag
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: ${{ secrets.DOCKER_USERNAME }}/frc:latest
+      - name: Push image with commit hash as tag
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: ${{ secrets.DOCKER_USERNAME }}/frc:${{ github.sha }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -17,12 +17,15 @@ jobs:
       - name: Pull image
         run: docker pull ${{ secrets.DOCKER_USERNAME }}/frc:latest
       - name: Build container # TODO run a script, or use action?
-        run: docker build --pull -t ${{ secrets.DOCKER_PASSWORD }}/frc:${{ github.sha }} -t ${{ secrets.DOCKER_PASSWORD }}/frc:latest . --cache-from ${{ secrets.DOCKER_PASSWORD }}/frc:latest
+        run: docker build --pull -t ${{ secrets.DOCKER_USERNAME }}/frc:${{ github.sha }} -t ${{ secrets.DOCKER_USERNAME }}/frc:latest . --cache-from ${{ secrets.DOCKER_USERNAME }}/frc:latest
       - name: Publish
-        run: docker run -it -e CRATESIO_TOKEN -e TRAVIS_TAG "$DOCKER_USERNAME"/frc:"$TRAVIS_COMMIT" sh -c "cd /first-rust-competition; make ci"
+        run: |
+          TRAVIS_TAG=$(echo $TRAVIS_TAG | cut -d'/' -f3)
+          docker run -it -e CRATESIO_TOKEN -e TRAVIS_TAG ${{ secrets.DOCKER_USERNAME }}/frc:${{ github.sha }} sh -c "cd /first-rust-competition; make ci"
         env:
           CRATESIO_TOKEN: ${{ secrets.CRATESIO_TOKEN }}
-          TRAVIS_TAG: ${{ github.sha }}
+          TRAVIS_TAG: ${{ github.ref }}
+          
       - name: Push image with latest tag
         uses: docker/build-push-action@v2
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,85 @@
+name: Publish to Crates.io
+
+on: # TODO Needs to be on tag / release
+  pull_request:
+    branches: [master]
+
+env:
+  CRATESIO_TOKEN: ${{ secrets.CRATESIO_TOKEN }} # TODO create org secret
+
+jobs: # using jobs to publish everything in parallel
+
+  publish_wpilib:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check Out Repo
+        uses: actions/checkout@v2
+      - name: Rust Toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          components: rustfmt, clippy
+      - name: cd wpilib
+        run: cd wpilib
+      - name: Package wpilib
+        uses: actions-rs/cargo@v1
+        with:
+          command: package
+      - name: Publish wpilib
+        uses: actions-rs/cargo@v1
+        with:
+          command: publish
+          args: --token $CRATESIO_TOKEN ## test this using --dry-run
+
+  publish_cargo-frc:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check Out Repo
+        uses: actions/checkout@v2
+      - name: Rust Toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          components: rustfmt, clippy
+      - name: cd cargo-frc
+        run: cd cargo-frc
+      - name: Package cargo-frc
+        uses: actions-rs/cargo@v1
+        with:
+          command: package
+      - name: Publish cargo-frc
+        uses: actions-rs/cargo@v1
+        with:
+          command: publish
+          args: --token $CRATESIO_TOKEN ## test this using --dry-run
+        
+  publish_wpilib-sys:
+    # allows dirty packaging and publishing. This is because c bindings are dynamically generated
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check Out Repo
+        uses: actions/checkout@v2
+      - name: Rust Toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          components: rustfmt, clippy
+      - name: cd wpilib-sys
+        run: cd wpilib-sys
+      - name: Package wpilib-sys
+        uses: actions-rs/cargo@v1
+        with:
+          command: package
+          args: --allow-dirty
+      - name: Publish wpilib-sys
+        uses: actions-rs/cargo@v1
+        with:
+          command: publish
+          args: --allow-dirty --token $CRATESIO_TOKEN ## test this using --dry-run
+        

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@
 # * git
 # * libclang / clang / llvm
 # * OpenJDK 11
-# * Python 2.7
+# * Python 3
 # * arm-frc2019-linux-gnueabi-gcc/g++
 #
 # Check the apt-get commands for the canonical list
@@ -30,7 +30,7 @@ RUN set -eux; \
     llvm-7-dev \
     libclang-7-dev \
     clang-7 \
-    python \
+    python3 \
     ;
 
 # add the frc2019 compiler

--- a/wpilib-sys/load-gcc-arm-headers.py
+++ b/wpilib-sys/load-gcc-arm-headers.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 
 # Copyright 2018 First Rust Competition Developers.
 # Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
@@ -27,7 +27,7 @@ def main():
     for x in include_dirs:
         x = x.strip()
         #call('cp -R {0}/* {1}'.format(x, "./include"), shell=True)
-        print x
+        print(x)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #77 

1. Please create [github secrets](https://docs.github.com/en/actions/reference/encrypted-secrets) for crates.io token, docker username, docker password. You likely want to create [org secrets](https://docs.github.com/en/actions/reference/encrypted-secrets#creating-encrypted-secrets-for-an-organization) for reuse across repos. Rename the references to the secrets to use the correct name (search for `${{ }}`)
2. How is each workflow triggered? On push, commit, tag? 
3. How exactly is docker being used in this project (dev, build, CI, test)? Its been a while since your [latest travis run](https://travis-ci.com/github/first-rust-competition/first-rust-competition) (and I assume docker image as well). If docker is completely extraneous, then both the workflows end up being the same, with different triggers.