### PR TITLE
[cargo-frc] Add support for less-common network configurations

### DIFF
--- a/cargo-frc/src/deploy.rs
+++ b/cargo-frc/src/deploy.rs
@@ -58,7 +58,7 @@ fn make_addresses(team_number: u64) -> Vec<String> {
 
         // The following are addresses that exist in uncommon development environments
         // Some teams run a shop wifi network that acts as a practice field. 
-        // This setup involves the following mDNS entries
+        // This setup involves the following DNS entries
         format!("roborio-{}-FRC", team_number),
         format!("roborio-{}-FRC.lan", team_number),
         format!("roborio-{}-FRC.frc-field.local", team_number),

--- a/cargo-frc/src/deploy.rs
+++ b/cargo-frc/src/deploy.rs
@@ -55,6 +55,13 @@ fn make_addresses(team_number: u64) -> Vec<String> {
         format!("roborio-{}-FRC.local", team_number),
         format!("10.{}.{}.2", team_number / 100, team_number % 100),
         "172.22.11.2".to_string(),
+
+        // The following are addresses that exist in uncommon development environments
+        // Some teams run a shop wifi network that acts as a practice field. 
+        // This setup involves the following mDNS entries
+        format!("roborio-{}-FRC", team_number),
+        format!("roborio-{}-FRC.lan", team_number),
+        format!("roborio-{}-FRC.frc-field.local", team_number),
     ]
 }
 


### PR DESCRIPTION
This is a pretty quick PR that adds a few more hosts to the `make_addresses` function in cargo-frc. Some teams run shop-wide FMS systems that change how the RoboRIO broadcasts itself over mDNS.

The changes I've made are also seen in the [`GradleRIO source`](https://github.com/wpilibsuite/GradleRIO/blob/aaf4da44e914a49e0bb956b028130481f538b31c/src/main/groovy/edu/wpi/first/gradlerio/frc/RoboRIO.groovy#L37-L50)